### PR TITLE
Adjust Markdown Headings for Versions in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### 0.9.9 (2022-07-05)
+## 0.9.9 (2022-07-05)
 
-### 0.9.8 (2022-07-04)
+## 0.9.8 (2022-07-04)
 
 
 ### Features
@@ -18,37 +18,37 @@ All notable changes to this project will be documented in this file. See [standa
 
 * remove typo from error handling ([#297](https://github.com/js-soft/wdi5/issues/297)) ([d549c74](https://github.com/js-soft/wdi5/commit/d549c747f15c750d94884cefbb497c866ce5133c))
 
-### 0.9.6 (2022-06-29)
+## 0.9.6 (2022-06-29)
 
-### 0.9.5 (2022-06-24)
+## 0.9.5 (2022-06-24)
 
 
 ### Features
 
 * add multiremote support ([#272](https://github.com/js-soft/wdi5/issues/272)) ([fcb47cf](https://github.com/js-soft/wdi5/commit/fcb47cf1047c30ef653a890e022472afe885d613)), closes [#281](https://github.com/js-soft/wdi5/issues/281)
 
-### 0.9.4 (2022-06-21)
+## 0.9.4 (2022-06-21)
 
 
 ### Bug Fixes
 
 * FE testLibrary initialization ([#286](https://github.com/js-soft/wdi5/issues/286)) ([d5fddee](https://github.com/js-soft/wdi5/commit/d5fddeeb348eb503288a8f8978e58204d0642494)), closes [#276](https://github.com/js-soft/wdi5/issues/276)
 
-### 0.9.3 (2022-06-20)
+## 0.9.3 (2022-06-20)
 
 
 ### Bug Fixes
 
 * avoid referenced object manipulation ([#275](https://github.com/js-soft/wdi5/issues/275)) ([#280](https://github.com/js-soft/wdi5/issues/280)) ([a069544](https://github.com/js-soft/wdi5/commit/a069544166c4ba9b1494f63190bef121611d3229))
 
-### 0.9.2 (2022-06-15)
+## 0.9.2 (2022-06-15)
 
 
 ### Features
 
 * improved sync with ui5 core lifecycle ([#278](https://github.com/js-soft/wdi5/issues/278)) ([53e1a7e](https://github.com/js-soft/wdi5/commit/53e1a7e952a84825feb9b42a8a9a2684b2ff71f9))
 
-### 0.9.1 (2022-05-23)
+## 0.9.1 (2022-05-23)
 
 
 ### Features


### PR DESCRIPTION
Since Version `0.9.1` the Headings for the Verions are `H3` instead of `H2` as previously.
Could not really tell what changed, maybe `standard-version`?

I´d like to parse changelog.md for changes and this would not work here.

I don't know if a manual change is appropriate here, but I'll just create the PR.
There is already an issue with changing the standard-version anyway #293 
