### PR TITLE
Selector specific logging

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,12 +71,15 @@ The `forceSelect` option also updates the `wdio` control reference each time a m
 
 The `timeout` option (default based on the global configuration `waitForUI5Timeout` [setting](wdio-ui5-service/README.md#installation)) controls the maximum waiting time while checking for UI5 availability _(meaning no pending requests / promises / timeouts)_.
 
+The `logging` (default: `true`) property can be set to `false` to disable the log for this specific selector. This can be useful when you want to assert, that specific controls should not be visible on the UI to decrease the amount of pointless error messages.
+
 ```javascript
 it("validates that $control's text is ...", async () => {
   const oSelector = {
     wdio_ui5_key: "wdio-ui5-button", // optional unique internal key to map and find a control
     forceSelect: true, // forces the test framework to again retrieve the control from the browser context
     timeout: 15000, // maximum waiting time (ms) before failing the search
+    logging: false, // optional (default: `true`) disables the log for this specific selector
     selector: {
       // sap.ui.test.RecordReplay.ControlSelector
       id: "UI5control_ID",

--- a/examples/ui5-js-app/webapp/test/e2e/error-logging.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/error-logging.test.js
@@ -193,3 +193,126 @@ describe("Error logging", () => {
         ).toBeTruthy()
     })
 })
+
+/**
+ * test that the wdi5 logger can be disabled for specific selectors
+ * for every test we are using a slightly different selector so we don't have
+ * to use "foceSelect: true" all the time
+ */
+describe("No error logging", () => {
+    const sandbox = sinon.createSandbox()
+
+    beforeEach(() => {
+        sandbox.spy(console, "red")
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+    it("should log nothing when control was not found", async () => {
+        const selectorWithWrongId = {
+            logging: false,
+            selector: {
+                id: "wrongIdNoLog"
+            }
+        }
+        await browser.asControl(selectorWithWrongId)
+        expect(console.red.callCount).toEqual(0)
+    })
+
+    it("should log when control was not found with 'logging' explicitly set to 'true'", async () => {
+        const selectorWithWrongId = {
+            logging: true,
+            selector: {
+                id: "wrongIdExplicitLog"
+            }
+        }
+        const wdi5ControlWithWrongId = await browser.asControl(selectorWithWrongId)
+
+        expectDefaultErrorMessages(wdi5ControlWithWrongId)
+        expect(console.red.callCount).toEqual(2)
+    })
+
+    it("should log nothing when 'press' is executed on an not found control; WITHOUT fluent async api", async () => {
+        const selectorWithWrongId = {
+            logging: false,
+            selector: {
+                id: "wrongIdWithPressNoLog"
+            }
+        }
+        wdi5ControlWithWrongIdNoLog = await browser.asControl(selectorWithWrongId)
+        await wdi5ControlWithWrongIdNoLog.press()
+        expect(console.red.callCount).toEqual(0)
+    })
+
+    it("should log nothing when 'press' is executed on an not found control; WITH fluent async api", async () => {
+        const selectorWithWrongId = {
+            logging: false,
+            selector: {
+                id: "wrongIdWithPressNoLogFluentAsync"
+            }
+        }
+        wdi5ControlWithWrongIdNoLog = await browser.asControl(selectorWithWrongId).press()
+
+        expect(console.red.callCount).toEqual(0)
+    })
+
+    it("should log nothing when 'enterText' is executed on an not found control; WITHOUT fluent async api", async () => {
+        const selectorWithWrongId = {
+            logging: false,
+            selector: {
+                id: "wrongIdWithEnterTextNoLog"
+            }
+        }
+
+        const wdi5ControlWithWrongId = await browser.asControl(selectorWithWrongId)
+        await wdi5ControlWithWrongId.enterText("test")
+
+        expect(console.red.callCount).toEqual(0)
+    })
+    it("should log nothing when 'enterText' is executed on an not found control; WITH fluent async api", async () => {
+        const selectorWithWrongId = {
+            logging: false,
+            selector: {
+                id: "wrongIdWithEnterTextNoLogFluentAsync"
+            }
+        }
+
+        await browser.asControl(selectorWithWrongId).enterText()
+
+        expect(console.red.callCount).toEqual(0)
+    })
+
+    it("should log nothing when multiple functions are executed on an control where an error in the queue occurrs; WITH fluent async api", async () => {
+        const selectorWithWrongId = {
+            logging: false,
+            forceSelect: true, // we need the forceSelect as the NavFwdButton was already located
+            selector: {
+                id: "container-Sample---Main--NavFwdButton"
+            }
+        }
+
+        await browser.asControl(selectorWithWrongId).getWrongFunction().getSecondWrongFunction()
+
+        expect(console.red.callCount).toEqual(0)
+    })
+
+    it("should log the first selector but not the second", async () => {
+        const firstSelectorWithLog = {
+            selector: {
+                id: "wrongIdWithLog"
+            }
+        }
+        const secondSelectorNoLog = {
+            logging: false,
+            selector: {
+                id: "wrongIdWithoutLog"
+            }
+        }
+        const wdi5ControlWithLogOutput = await browser.asControl(firstSelectorWithLog)
+        await browser.asControl(secondSelectorNoLog)
+
+        expectDefaultErrorMessages(wdi5ControlWithLogOutput)
+        expect(console.red.callCount).toEqual(2)
+    })
+})

--- a/src/lib/wdi5-bridge.ts
+++ b/src/lib/wdi5-bridge.ts
@@ -348,6 +348,8 @@ export async function _addWdi5Commands(browserInstance: WebdriverIO.Browser) {
         browserInstance.asControl = function (ui5ControlSelector) {
             const asyncMethods = ["then", "catch", "finally"]
             const functionQueue = []
+            // we need to do the same operation as in the 'init' of 'wdi5-control.ts'
+            const logging = ui5ControlSelector?.logging ?? true
             function makeFluent(target) {
                 const promise = Promise.resolve(target)
                 const handler = {
@@ -362,7 +364,9 @@ export async function _addWdi5Commands(browserInstance: WebdriverIO.Browser) {
                                           return object[prop]
                                       } catch (error) {
                                           // different node versions return a different `error.message` so we use our own message
-                                          Logger.error(`Cannot read property '${prop}' in the execution queue!`)
+                                          if (logging) {
+                                              Logger.error(`Cannot read property '${prop}' in the execution queue!`)
+                                          }
                                       }
                                   })
                               )
@@ -376,7 +380,7 @@ export async function _addWdi5Commands(browserInstance: WebdriverIO.Browser) {
                                 } else {
                                     // a functionQueue without a 'then' can be ignored
                                     // as the original error was already logged
-                                    if (functionQueue.includes("then")) {
+                                    if (functionQueue.includes("then") && logging) {
                                         functionQueue.splice(functionQueue.indexOf("then"))
                                         Logger.error(
                                             `One of the calls in the queue "${functionQueue.join(

--- a/src/types/wdi5.types.ts
+++ b/src/types/wdi5.types.ts
@@ -120,6 +120,10 @@ export interface wdi5Selector {
      * OPA5-style selectors from RecordReplay
      */
     selector: wdi5ControlSelector
+    /**
+     * disables the logging for the selector
+     */
+    logging?: boolean
 }
 
 /**


### PR DESCRIPTION
A new property `logging` (default: `true`) is added to the wdi5 selectors. When `logging` is set to `false` no logs will be written and shown in the terminal for this specific selector.

Closes #331 