### PR TITLE
Make wdi5 config optional

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -15,6 +15,11 @@ export default class Service implements Services.ServiceInstance {
     ) {}
 
     async before(/*capabilities* , specs*/) {
+        // if no wdi5 config is available we add it manually
+        if (!this._config.wdi5) {
+            this._config["wdi5"] = {}
+        }
+
         await start(this._config)
         Logger.info("started")
         await setup(this._config)

--- a/src/types/wdi5.types.ts
+++ b/src/types/wdi5.types.ts
@@ -23,7 +23,7 @@ import { WDI5Object } from "../lib/wdi5-object"
 export type wdi5LogLevel = "silent" | "error" | "verbose"
 
 export interface wdi5Config extends WebdriverIO.Config {
-    wdi5: {
+    wdi5?: {
         /** wdi5-specific logging of UI5-related operations */
         logLevel?: wdi5LogLevel
         /**


### PR DESCRIPTION
As now all wdi5 specific properties are optional we can make the whole wdi5 config object optional as well. 
To not break existing code, we have to add the wdi5 object programmatically to allow for further checks on this wdi5 object