### PR TITLE
fix: wait for the injection of wdi5 till the redirection finished

### DIFF
--- a/src/lib/wdi5-bridge.ts
+++ b/src/lib/wdi5-bridge.ts
@@ -131,16 +131,16 @@ export async function injectUI5(config: wdi5Config, browserInstance) {
     return result
 }
 
-export async function checkForUI5Page() {
+export async function checkForUI5Page(browserInstance) {
     // wait till the loading finished and the state is "completed"
-    await browser.waitUntil(async () => {
-        const state = await browser.executeAsync((done) => {
+    await browserInstance.waitUntil(async () => {
+        const state = await browserInstance.executeAsync((done) => {
             done(document.readyState)
         })
         return state === "complete"
     })
     // sap in global window namespace denotes (most likely :) ) that ui5 is present
-    return await browser.executeAsync((done) => {
+    return await browserInstance.executeAsync((done) => {
         done(!!window.sap)
     })
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -53,8 +53,8 @@ export default class Service implements Services.ServiceInstance {
      * to the injectUI5 function of the actual wdi5-bridge
      */
     async injectUI5(browserInstance = browser) {
-        if (await checkForUI5Page()) {
-            await injectUI5(browserInstance.config as wdi5Config, browserInstance)
+        if (await checkForUI5Page(browserInstance)) {
+            await injectUI5(this._config as wdi5Config, browserInstance)
         } else {
             throw new Error("wdi5: no UI5 page/app present to work on :(")
         }

--- a/src/service.ts
+++ b/src/service.ts
@@ -54,7 +54,9 @@ export default class Service implements Services.ServiceInstance {
      */
     async injectUI5(browserInstance = browser) {
         if (await checkForUI5Page(browserInstance)) {
-            await injectUI5(this._config as wdi5Config, browserInstance)
+            // depending on the scenario (lateInject, multiRemote) we have to access the config differently
+            const config = this._config ? this._config : browserInstance.config
+            await injectUI5(config as wdi5Config, browserInstance)
         } else {
             throw new Error("wdi5: no UI5 page/app present to work on :(")
         }

--- a/src/service.ts
+++ b/src/service.ts
@@ -30,7 +30,7 @@ export default class Service implements Services.ServiceInstance {
                     await authenticate(this._capabilities[name].capabilities["wdi5:authentication"], name)
                 }
                 if (!this._config.wdi5.skipInjectUI5OnStart) {
-                    await injectUI5(this._config as wdi5Config, browser[name])
+                    await this.injectUI5(browser[name])
                 } else {
                     Logger.warn("skipped wdi5 injection!")
                 }
@@ -40,7 +40,7 @@ export default class Service implements Services.ServiceInstance {
                 await authenticate(this._capabilities["wdi5:authentication"])
             }
             if (!this._config.wdi5.skipInjectUI5OnStart) {
-                await injectUI5(this._config as wdi5Config, browser)
+                await this.injectUI5(browser)
             } else {
                 Logger.warn("skipped wdi5 injection!")
             }


### PR DESCRIPTION
In some cases the redirection and the loading of the ui5 application takes a little bit longer. Currently wdi5 does not wait for that after the authentication.