### PR TITLE
Selecting Dialog twice needs `forceSelect`

### DIFF
--- a/examples/ui5-js-app/webapp/test/e2e/press.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/press.test.js
@@ -10,7 +10,6 @@ describe("custom wdi5 press event", async () => {
     }
 
     const dialogSelector = {
-        forceSelect: true,
         selector: {
             id: "Dialog",
             controlType: "sap.m.Dialog",


### PR DESCRIPTION
This is not a PR, more a Issue but i can better ilustrate my problem.
I just stumbled across this error.
If I want to select the dialog a second time, I have to use "forceSelect", otherwise I get this error.
`stale element reference: element is not attached to the page document
  (Session info: chrome=109.0.5414.75)`
There is no other way here, right?