### PR TITLE
Make saveObject() work in unsecure contexts

### DIFF
--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -35,7 +35,11 @@ async function clientSide_injectUI5(config, waitForUI5Timeout, browserInstance) 
              * @returns uuid
              */
             window.wdi5.saveObject = (object) => {
-                const uuid = crypto.randomUUID()
+                // This is a manual replacement for crypto.randomUUID()
+                // until it is only available in secure contexts.
+                // See https://github.com/WICG/uuid/issues/23
+                const uuid = ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
+                    ( c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16) )
                 window.wdi5.objectMap[uuid] = object
                 return uuid
             }

--- a/examples/ui5-js-app/webapp/test/e2e/aggregation.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/aggregation.test.js
@@ -11,7 +11,7 @@ describe("ui5 aggregation retrieval", () => {
         browser.screenshot("aggregation")
     })
 
-    it.only("check the getBinding of a table", async () => {
+    it("check the getBinding of a table", async () => {
         const mytable = await Other.getList()
         const firstrow = await mytable.getItems(0)
         const rowcontext = await firstrow.getBindingContext()
@@ -19,7 +19,7 @@ describe("ui5 aggregation retrieval", () => {
 
         expect(myobject.FirstName).toEqual("Nancy")
     })
-    
+
     it("select controls of a sap.m.Page's content aggregation", async () => {
         // goal: assert that .getContent() and .getAggregation("items") work the same
         // including access via the fluent async api

--- a/examples/ui5-js-app/webapp/test/e2e/aggregation.test.js
+++ b/examples/ui5-js-app/webapp/test/e2e/aggregation.test.js
@@ -11,6 +11,15 @@ describe("ui5 aggregation retrieval", () => {
         browser.screenshot("aggregation")
     })
 
+    it.only("check the getBinding of a table", async () => {
+        const mytable = await Other.getList()
+        const firstrow = await mytable.getItems(0)
+        const rowcontext = await firstrow.getBindingContext()
+        const myobject = await rowcontext.getObject()
+
+        expect(myobject.FirstName).toEqual("Nancy")
+    })
+    
     it("select controls of a sap.m.Page's content aggregation", async () => {
         // goal: assert that .getContent() and .getAggregation("items") work the same
         // including access via the fluent async api


### PR DESCRIPTION
A solution for #416 . Calculates the UUID using getRandomValues() until randomUUID() is only available in secure contexts (HTTPS and localhost).