### PR TITLE
feat: enhanced types

### DIFF
--- a/examples/ui5-ts-app/test/e2e/Basic.test.ts
+++ b/examples/ui5-ts-app/test/e2e/Basic.test.ts
@@ -17,7 +17,7 @@ describe("Basic", async () => {
             }
         }
 
-        const allButtons = (await browser.allControls(allButtonsSelector)) as unknown as Array<Button>
+        const allButtons = await browser.allControls<Button>(allButtonsSelector)
         expect(allButtons.length).toEqual(1)
     })
 
@@ -28,7 +28,7 @@ describe("Basic", async () => {
                 viewName: "test.Sample.tsapp.view.Main"
             }
         }
-        const view: unknown = await (browser.asControl(selector) as unknown as Page).getParent()
+        const view = await (browser.asControl(selector) as unknown as Page).getParent()
         const controller: Controller = await (view as View).getController()
 
         // @ts-ignore this async fn lives in an not properly typed controller

--- a/examples/ui5-ts-app/test/e2e/Input.test.ts
+++ b/examples/ui5-ts-app/test/e2e/Input.test.ts
@@ -9,8 +9,9 @@ describe("Input", async () => {
                 viewName: "test.Sample.tsapp.view.Main"
             }
         }
-        const inputString: string = await (browser.asControl(inputText) as unknown as Input).getValue()
-        expect(inputString).toEqual("Helvetius Nagy")
+        const input = await browser.asControl<Input>(inputText)
+        const value = await input.getValue()
+        expect(value).toEqual("Helvetius Nagy")
     })
 
     it("should check if the field is writeable", async () => {

--- a/examples/ui5-ts-app/test/e2e/MultiInput.test.ts
+++ b/examples/ui5-ts-app/test/e2e/MultiInput.test.ts
@@ -14,7 +14,7 @@ describe("MultiInput", async () => {
         // @ts-ignore
         await (browser.asControl(multiInputSelector) as unknown as MultiInput).enterText("123")
 
-        const multiInput = (await browser.asControl(multiInputSelector)) as unknown as MultiInput
+        const multiInput = await browser.asControl<MultiInput>(multiInputSelector)
         const text = await multiInput.getValue()
         expect(text).toEqual("123")
     })

--- a/examples/ui5-ts-app/test/e2e/Navigation.test.ts
+++ b/examples/ui5-ts-app/test/e2e/Navigation.test.ts
@@ -5,14 +5,13 @@ import { wdi5Selector } from "wdio-ui5-service/dist/types/wdi5.types"
 describe("Navigation", async () => {
     it("nav to other view and check if successful", async () => {
         // click webcomponent button to trigger navigation
-        await (
-            browser.asControl({
-                selector: {
-                    id: "NavFwdButton",
-                    viewName: "test.Sample.tsapp.view.Main"
-                }
-            }) as unknown as Button
-        ).fireClick()
+        const navButton = await browser.asControl<Button>({
+            selector: {
+                id: "NavFwdButton",
+                viewName: "test.Sample.tsapp.view.Main"
+            }
+        })
+        await navButton.press()
 
         const listSelector: wdi5Selector = {
             selector: {

--- a/examples/ui5-ts-app/test/e2e/multiremote.test.ts
+++ b/examples/ui5-ts-app/test/e2e/multiremote.test.ts
@@ -10,9 +10,9 @@ describe("Basic", async () => {
             }
         }
         // @ts-ignore
-        const allButtonsTwo = (await browser.two.allControls(allButtonsSelector)) as unknown as Array<Button>
+        const allButtonsTwo = await browser.two.allControls<Button>(allButtonsSelector)
         // @ts-ignore
-        const allButtonsOne = (await browser.one.allControls(allButtonsSelector)) as unknown as Array<Button>
+        const allButtonsOne = await browser.one.allControls<Button>(allButtonsSelector)
         expect(allButtonsTwo.length).toEqual(1)
         expect(allButtonsOne.length).toEqual(1)
     })

--- a/src/types/browser-commands.ts
+++ b/src/types/browser-commands.ts
@@ -14,10 +14,10 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace WebdriverIO {
         export interface Browser {
-            asControl: (arg: wdi5Selector) => Promise<WDI5Control & Control> // Intersection Types
-            allControls: (arg: wdi5Selector) => Promise<WDI5Control & Control> // Intersection Types
-            screenshot: (arg: string) => Promise<any>
-            goTo: (arg: string | object) => Promise<any>
+            asControl: <T extends Control = Control>(arg: wdi5Selector) => Promise<WDI5Control & T>
+            allControls: <T extends Control = Control>(arg: wdi5Selector) => Promise<(WDI5Control & T)[]>
+            screenshot: (arg: string) => Promise<void>
+            goTo: (arg: string | object) => Promise<void>
             /**
              * adding the wdi5 control cache to the global browser object
              */


### PR DESCRIPTION
this change provides a better DevX when `wdi5` is used w/ TS.

before: 
```ts 
const multiInput = (await browser.asControl(multiInputSelector)) as unknown as MultiInput
```
after: 
```ts
const multiInput = await browser.asControl<MultiInput>(multiInputSelector)
```

other samples "after":
```ts
const allButtons = await browser.allControls<Button>(allButtonsSelector)
const allButtonsOne = await browser.one.allControls<Button>(allButtonsSelector)
const navButton = await browser.asControl<Button>({
      selector: {
          id: "NavFwdButton",
          viewName: "test.Sample.tsapp.view.Main"
      }
  })
await navButton.press()
```

_caveat_: this does not apply to the fluent async api!

(kudos to @jkoenig134 for the jumpstart!)