### PR TITLE
fix: publish btp workflow

### DIFF
--- a/.github/workflows/publish-btp.yml
+++ b/.github/workflows/publish-btp.yml
@@ -33,6 +33,7 @@ jobs:
             examples/ui5-ts-app/mta_archives/ui5-approuter_1.0.0.mtar
 
   publish-sample-ts-app-to-btp:
+    needs: build-sample-ts-app
     runs-on: ubuntu-latest
     container: ppiper/cf-cli
     steps:


### PR DESCRIPTION
both jobs run on the same time, but the job `publish-sample-ts-app-to-btp` depends on the build from job `build-sample-ts-app` That´s why deploy job failed because the artifact simply does not exist yet

https://github.com/ui5-community/wdi5/actions/runs/4261099722
![image](https://user-images.githubusercontent.com/13335743/225258178-ac47a9df-42c4-44f0-bc3a-b00eb5790b6b.png)
![image](https://user-images.githubusercontent.com/13335743/225258199-34261c34-a255-4472-a60b-01bfe2dc1ccd.png)


closes #432

