### PR TITLE
fix for waitAsync is already running bug

### DIFF
--- a/client-side-js/injectUI5.js
+++ b/client-side-js/injectUI5.js
@@ -26,7 +26,9 @@ async function clientSide_injectUI5(config, waitForUI5Timeout, browserInstance) 
                 },
                 objectMap: {
                     // GUID: {}
-                }
+                },
+                bWaitStarted: false,
+                asyncControlRetrievalQueue: []
             }
 
             /**
@@ -57,13 +59,26 @@ async function clientSide_injectUI5(config, waitForUI5Timeout, browserInstance) 
                     oOptions = oOptions || {}
                     _autoWaiterAsync.extendConfig(oOptions)
 
-                    _autoWaiterAsync.waitAsync(function (sError) {
-                        if (sError) {
-                            errorCallback(new Error(sError))
-                        } else {
-                            callback()
-                        }
-                    })
+                    const startWaiting = function () {
+                        window.wdi5.bWaitStarted = true;
+                        _autoWaiterAsync.waitAsync(function (sError) {
+                            window.wdi5.bWaitStarted = false;
+                            const nextWaitAsync = window.wdi5.asyncControlRetrievalQueue.shift();
+                            if (nextWaitAsync) {
+                                setTimeout(nextWaitAsync); //use setTimeout to postpone execution to the next event cycle, so that bWaitStarted in the UI5 _autoWaiterAsync is also set to false first
+                            }
+                            if (sError) {
+                                errorCallback(new Error(sError))
+                            } else {
+                                callback()
+                            }
+                        })
+                    }
+                    if (!window.wdi5.bWaitStarted) {
+                        startWaiting();
+                    } else {
+                        window.wdi5.asyncControlRetrievalQueue.push(startWaiting);
+                    }
                 }
                 window.wdi5.Log.info("[browser wdi5] window._autoWaiterAsync used in waitForUI5 function")
             })


### PR DESCRIPTION
https://github.com/ui5-community/wdi5/issues/452

This fix is working for me, but I have addressed it from a symptomatic point of view. I do not have the insights to say whether this is the best way to fix it. Either it is, or it might also give you some idea how to fix it the right way.

The problem is really, that the waitForUI5 function triggers the _autoWaiterAsync waiting multiple times in parallel, which it does not allow, the reason for it is given in a comment on the function:

> // start only one waiter at a time to prevent interference between the timeout detection of multiple waiters