### PR TITLE
docs: add `copy to clipboard` to code snippets

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,7 @@
         </script>
         <!-- Docsify v4 -->
         <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+        <script src="https://unpkg.com/docsify-copy-code"></script>
         <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
         <!-- docsify-themeable (latest v0.x.x) -->
         <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/js/docsify-themeable.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "chromedriver": "latest",
     "cross-env": "^7.0.3",
     "deepmerge": "^4.2.2",
+    "docsify-cli": "4.4.4",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
add feature to docs `copy to clipboard` from https://github.com/jperasmus/docsify-copy-code
also add `docsify-cli` to package.json so you can run the `startDoc` command and not need to install the cli yourself or globally

![image](https://github.com/ui5-community/wdi5/assets/13335743/9bf6f519-d135-4ced-aa79-282afdc3dc76)
