### PR TITLE
fix(types): expose types of WDI5Control via wdi5.types.ts

### DIFF
--- a/src/types/wdi5.types.ts
+++ b/src/types/wdi5.types.ts
@@ -261,3 +261,5 @@ export interface wdi5Bridge extends Window {
         }
     }
 }
+
+export type { WDI5Control as wdi5Control } from "../lib/wdi5-control"


### PR DESCRIPTION
Fixes https://github.com/ui5-community/wdi5/issues/544

This PR provides the types for WDI5Control to be used by people building typed matchers. It adheres to the naming-convention of being lowercase in the export. Additionally, we just export the type, as noone outside the framework should be able to instantiate a WDI5Control.