### PR TITLE
fix: remove empty array elements to reduce scope transfer size

### DIFF
--- a/client-side-js/executeControlMethod.cjs
+++ b/client-side-js/executeControlMethod.cjs
@@ -80,13 +80,16 @@ async function executeControlMethod(webElement, methodName, browserInstance, arg
                                 const collapsedAndNonCyclic = JSON.parse(
                                     JSON.stringify(collapsed, window.wdi5.getCircularReplacer())
                                 )
+                                // remove all empty Array elements, inlcuding private keys (starting with "_")
+                                const semanticCleanedElements = window.wdi5.removeEmptyElements(collapsedAndNonCyclic)
+
                                 done({
                                     status: 0,
-                                    object: collapsedAndNonCyclic,
+                                    object: semanticCleanedElements,
                                     returnType: "object",
                                     aProtoFunctions: aProtoFunctions,
                                     uuid: uuid,
-                                    nonCircularResultObject: collapsedAndNonCyclic
+                                    nonCircularResultObject: semanticCleanedElements
                                 })
                             } else if (
                                 typeof result === "object" &&

--- a/client-side-js/executeObjectMethod.cjs
+++ b/client-side-js/executeObjectMethod.cjs
@@ -44,10 +44,12 @@ async function clientSide_executeObjectMethod(uuid, methodName, args) {
                         const collapsedAndNonCyclic = JSON.parse(
                             JSON.stringify(result, window.wdi5.getCircularReplacer())
                         )
+                        // remove all empty Array elements, inlcuding private keys (starting with "_")
+                        const semanticCleanedElements = window.wdi5.removeEmptyElements(collapsedAndNonCyclic)
 
                         done({
                             status: 0,
-                            object: collapsedAndNonCyclic,
+                            object: semanticCleanedElements,
                             uuid: uuid,
                             returnType: "object",
                             aProtoFunctions: aProtoFunctions

--- a/client-side-js/getObject.cjs
+++ b/client-side-js/getObject.cjs
@@ -28,12 +28,15 @@ async function clientSide_getObject(uuid) {
 
                 const collapsedAndNonCyclic = JSON.parse(JSON.stringify(object, window.wdi5.getCircularReplacer()))
 
+                // remove all empty Array elements, inlcuding private keys (starting with "_")
+                const semanticCleanedElements = window.wdi5.removeEmptyElements(collapsedAndNonCyclic)
+
                 done({
                     status: 0,
                     uuid: uuid,
                     aProtoFunctions: aProtoFunctions,
                     className: className,
-                    object: collapsedAndNonCyclic
+                    object: semanticCleanedElements
                 })
             },
             window.wdi5.errorHandling.bind(this, done)

--- a/client-side-js/injectUI5.cjs
+++ b/client-side-js/injectUI5.cjs
@@ -320,6 +320,36 @@ async function clientSide_injectUI5(config, waitForUI5Timeout, browserInstance) 
                     }
 
                     /**
+                     * removes all empty collection members from an object,
+                     * e.g. empty, null, or undefined array elements
+                     *
+                     * @param {object} obj
+                     * @returns {object} obj without empty collection members
+                     */
+                    window.wdi5.removeEmptyElements = (obj, i = 0) => {
+                        for (let key in obj) {
+                            if (obj[key] === null || key.startsWith("_")) {
+                                delete obj[key]
+                            } else if (Array.isArray(obj[key])) {
+                                obj[key] = obj[key].filter(
+                                    (element) =>
+                                        element !== null &&
+                                        element !== undefined &&
+                                        element !== "" &&
+                                        Object.keys(element).length > 0
+                                )
+                                if (obj[key].length > 0) {
+                                    i++
+                                    window.wdi5.removeEmptyElements(obj[key], i)
+                                }
+                            } else if (typeof obj[key] === "object") {
+                                i++
+                                window.wdi5.removeEmptyElements(obj[key], i)
+                            }
+                        }
+                        return obj
+                    }
+                    /**
                      * if parameter is JS primitive type
                      * returns {boolean}
                      * @param {*} test


### PR DESCRIPTION
After going deep down the rabbit hole, it turns out that the binding context object in already a small FE app is _humongously_ huge. Thus, when (in Node.js) a `getBindingContext()` is called on a located control for subsequent asserts on the binding object, the binding context object transferred between the browser- and the Node.js-scope is > 100 MB (!), causing serialisation operations fail.

This PR "cleans" the located controls internal object properties already in browser-scope by removing all private properities (starting with `_`) and `null` Array members.
The "cleaned" object is then only a fraction of its original size, (hopefully) making everyone more happy.

Closes #557 