### PR TITLE
fix: explicitly add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "the UI5 community <do_not_use@openui5.org> (https://github.com/ui5-community)",
   "type": "module",
   "exports": {
+    "types": "./esm/index.d.ts",
     "import": "./esm/index.js",
     "require": "./cjs/index.js"
   },


### PR DESCRIPTION
The types are exported and should be able to be used by library consumers. However, when these consumers use recommended TypeScript `moduleResolution` setting "node16" (https://www.typescriptlang.org/tsconfig#moduleResolution), that will force the resolution to follow what is declared in the `exports` section of `package.json` -- where an explicit export of the types is currently missing.

Note that this is different from the `types` field at the top-level of `package.json`, which is a legacy mechanism for the old module resolution (this comment explains it pretty well for a different project, which dropped support for the legacy approach: https://github.com/typescript-eslint/typescript-eslint/pull/7186#issuecomment-1631373279).

As wdi5 is released with dual packaging (commonjs + esm), and both version should support typescript, keeping the top-level types field around makes sense. This is also what the wdio-reporter plugin does: https://github.com/webdriverio/webdriverio/blob/d3e494d089d0545cf14ca88043d9599eaf98fa53/packages/wdio-reporter/package.json#L35

They even go a step further and have subpath exports combined with the conditional exports that wdi5 has at the moment (see https://nodejs.org/api/packages.html#subpath-exports and https://nodejs.org/api/packages.html#conditional-exports). Given that in my project, the conditional export only approach works fine, I have opted to not add the subpath variant as well in this PR.