### PR TITLE
fix: basic authentication (#615)

### DIFF
--- a/src/lib/authentication/BasicAuthenticator.ts
+++ b/src/lib/authentication/BasicAuthenticator.ts
@@ -23,7 +23,9 @@ class BasicAuthenticator extends Authenticator {
     private async basicAuthLogin(basicAuthUrls: string[]) {
         for (const basicAuthUrlsConfig of basicAuthUrls) {
             const matches = basicAuthUrlsConfig.match(/(\w*:?\/\/)(.+)/)
-            const basicAuthUrls = matches[1] + this.getUsername() + ":" + this.getPassword() + "@" + matches[2]
+            const username = encodeURIComponent(this.getUsername())
+            const password = encodeURIComponent(this.getPassword())
+            const basicAuthUrls = matches[1] + username + ":" + password + "@" + matches[2]
             if (!matches[1] || !matches[2]) {
                 throw new Error(`Invalid basicAuthUrls config: ${basicAuthUrlsConfig}`)
             }


### PR DESCRIPTION
This PR will fix #615 where the content of the .env file is simply put inside the URL. But instead it should be encoded before used in an URL.