### PR TITLE
add: support for regex in ancestor ids

### DIFF
--- a/src/client-side-js/injectUI5.ts
+++ b/src/client-side-js/injectUI5.ts
@@ -149,6 +149,13 @@ async function clientSide_injectUI5(waitForUI5Timeout: number, browserInstance: 
                     const [sTarget, sRegEx, sFlags] = oSelector.id.match(/\/(.*)\/(.*)/)
                     oSelector.id = new RegExp(sRegEx, sFlags)
                 }
+                
+                // also check if ancestor uses regex
+                if (oSelector.ancestor && typeof oSelector.ancestor.id === "string" && (oSelector.ancestor.id as string).startsWith("/", 0)) {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const [sTarget, sRegEx, sFlags] = (oSelector.ancestor.id as string).match(/\/(.*)\/(.*)/)
+                    oSelector.ancestor.id = new RegExp(sRegEx, sFlags)
+                }
 
                 // match a regular regex as (partial) matcher
                 // properties: {

--- a/src/lib/wdi5-control.ts
+++ b/src/lib/wdi5-control.ts
@@ -667,6 +667,10 @@ export class WDI5Control {
             controlSelector.selector.id = controlSelector.selector.id.toString()
         }
 
+        // also allow regex for ancestors
+        if (controlSelector.selector.ancestor && typeof controlSelector.selector.ancestor.id === "object") {
+            controlSelector.selector.ancestor.id = controlSelector.selector.ancestor.id.toString();
+        }
         // check whether we have a (partial) text matcher
         // that should match:
         // properties: {


### PR DESCRIPTION
This is used to refer elements to ancestors whose ID may contain counters or other variable parts.