### PR TITLE
fix: emit dist/cjs/package.json and dist/esm/package.json type markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
   "scripts": {
     "// build time": "refers to developing wdi5/wdio-ui5-service itself",
     "clean": "rimraf cjs esm dist",
-    "build": "run-s -c clean _build:cjs _build:esm",
+    "build": "run-s -c clean _build:cjs _build:esm _finalize:dist",
     "_build:cjs": "tsc --p tsconfig-cjs.json",
     "_build:esm": "tsc --p tsconfig-esm.json",
+    "_finalize:dist": "node ./scripts/finalize-dist.cjs",
     "build:watch": "npm-run-all clean --parallel _build:watch:cjs _build:watch:esm",
     "_build:watch:cjs": "tsc -w --p tsconfig-cjs.json",
     "_build:watch:esm": "tsc -w --p tsconfig-esm.json",

--- a/scripts/finalize-dist.cjs
+++ b/scripts/finalize-dist.cjs
@@ -1,0 +1,17 @@
+// The package root declares "type": "module" (for the ESM build's own .js files
+// to be parsed correctly), but dist/cjs/*.js is emitted as CommonJS by
+// tsconfig-cjs.json. Without a dist/cjs/package.json override, Node resolves
+// dist/cjs/*.js against the root's "type": "module" and any require() of this
+// package throws "ReferenceError: exports is not defined in ES module scope".
+// Write the two marker files so each build output is parsed with the module
+// system it's actually written in.
+const fs = require("fs")
+const path = require("path")
+
+function writeTypeMarker(dir, type) {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ type }, null, 2) + "\n")
+}
+
+writeTypeMarker(path.join(__dirname, "..", "dist", "cjs"), "commonjs")
+writeTypeMarker(path.join(__dirname, "..", "dist", "esm"), "module")


### PR DESCRIPTION

## Problem

The package root `package.json` declares `"type": "module"`, but `dist/cjs/*.js` is emitted as CommonJS by `tsconfig-cjs.json` (`outDir: "./dist/cjs"`, `module: "commonjs"`). With no `dist/cjs/package.json` override, Node resolves that output against the root's `"type": "module"` and any `require("wdio-ui5-service")` throws:

```
ReferenceError: exports is not defined in ES module scope
```

This affects any CommonJS consumer that requires the package directly (not just via the `services` array) — e.g. instantiating the default export directly in `wdio.conf.js` to call `injectUI5()` manually.

## Fix

Add a build step (`_finalize:dist`, run as part of `npm run build`) that writes:
- `dist/cjs/package.json` → `{"type":"commonjs"}`
- `dist/esm/package.json` → `{"type":"module"}` (for symmetry, keeps the ESM output explicit too)

so each build output is parsed with the module system it's actually written in.

## Verification

Built locally and confirmed both entry points resolve correctly:

```
$ node -e "const wdi5 = require('./dist/cjs/index.js'); console.log(Object.keys(wdi5))"
require OK, keys: [ 'launcher', 'wdi5', 'ELEMENT_KEY', 'default' ]

$ node -e "import('./dist/esm/index.js').then(m => console.log(Object.keys(m)))"
import OK, keys: [ 'ELEMENT_KEY', 'default', 'launcher', 'wdi5' ]
```
